### PR TITLE
Add submodule with hamcrest matchers for optionals. Implements #19.

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,6 +2,8 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <bytecodeTargetLevel>
+      <module name="optional-testing_main" target="1.7" />
+      <module name="optional-testing_test" target="1.7" />
       <module name="optional_main" target="1.7" />
       <module name="optional_test" target="1.7" />
     </bytecodeTargetLevel>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,9 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/optional.iml" filepath="$PROJECT_DIR$/.idea/modules/optional.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/optional-testing.iml" filepath="$PROJECT_DIR$/.idea/modules/optional-testing.iml" group="optional-testing" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/optional-testing/optional-testing_main.iml" filepath="$PROJECT_DIR$/.idea/modules/optional-testing/optional-testing_main.iml" group="optional-testing" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/optional-testing/optional-testing_test.iml" filepath="$PROJECT_DIR$/.idea/modules/optional-testing/optional-testing_test.iml" group="optional-testing" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/optional_main.iml" filepath="$PROJECT_DIR$/.idea/modules/optional_main.iml" group="optional" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/optional_test.iml" filepath="$PROJECT_DIR$/.idea/modules/optional_test.iml" group="optional" />
     </modules>

--- a/optional-testing/build.gradle
+++ b/optional-testing/build.gradle
@@ -1,0 +1,30 @@
+apply plugin: 'java'
+
+def gitVersion = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
+group 'org.dmfs'
+version gitVersion()
+
+sourceCompatibility = 1.7
+
+configurations {
+    pom
+}
+
+apply from: '../publish.gradle'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile rootProject
+    compile group: 'junit', name: 'junit', version: '4.12'
+}

--- a/optional-testing/src/main/java/org/dmfs/optional/hamcrest/AbsentMatcher.java
+++ b/optional-testing/src/main/java/org/dmfs/optional/hamcrest/AbsentMatcher.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.optional.hamcrest;
+
+import org.dmfs.optional.Optional;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+
+/**
+ * @author Marten Gajda
+ */
+public final class AbsentMatcher extends TypeSafeDiagnosingMatcher<Optional<?>>
+{
+
+    public static AbsentMatcher isAbsent()
+    {
+        return new AbsentMatcher();
+    }
+
+
+    @Override
+    protected boolean matchesSafely(Optional<?> item, Description mismatchDescription)
+    {
+        if (item.isPresent())
+        {
+            mismatchDescription.appendText("present");
+        }
+        return !item.isPresent();
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("absent");
+    }
+}

--- a/optional-testing/src/main/java/org/dmfs/optional/hamcrest/PresentMatcher.java
+++ b/optional-testing/src/main/java/org/dmfs/optional/hamcrest/PresentMatcher.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.optional.hamcrest;
+
+import org.dmfs.optional.Optional;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.hamcrest.core.IsAnything;
+import org.hamcrest.core.IsEqual;
+
+
+/**
+ * A {@link Matcher} to match the presence and value of an {@link Optional}.
+ *
+ * @author Marten Gajda
+ */
+public final class PresentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<T>>
+{
+    public static <T> PresentMatcher<T> isPresent()
+    {
+        return new PresentMatcher<>();
+    }
+
+
+    public static <T> PresentMatcher<T> isPresent(T expectedValue)
+    {
+        return new PresentMatcher<>(expectedValue);
+    }
+
+
+    public static <T> PresentMatcher<T> isPresent(Matcher<T> delegate)
+    {
+        return new PresentMatcher<>(delegate);
+    }
+
+
+    private final Matcher<T> mDelegate;
+
+
+    public PresentMatcher()
+    {
+        this(new IsAnything<T>());
+    }
+
+
+    public PresentMatcher(T expected)
+    {
+        this(new IsEqual<>(expected));
+    }
+
+
+    public PresentMatcher(Matcher<T> delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(Optional<T> item, Description mismatchDescription)
+    {
+        if (!item.isPresent())
+        {
+            mismatchDescription.appendText("not present");
+            return false;
+        }
+        else if (!mDelegate.matches(item.value()))
+        {
+            mismatchDescription.appendText("present, but value ");
+            mDelegate.describeMismatch(item.value(), mismatchDescription);
+            return false;
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("present with value ");
+        mDelegate.describeTo(description);
+    }
+}

--- a/optional-testing/src/test/java/org/dmfs/optional/hamcrest/AbsentMatcherTest.java
+++ b/optional-testing/src/test/java/org/dmfs/optional/hamcrest/AbsentMatcherTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.optional.hamcrest;
+
+import org.dmfs.optional.Absent;
+import org.dmfs.optional.Present;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Description;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author marten
+ */
+public class AbsentMatcherTest
+{
+    @Test
+    public void testMatchesSafely() throws Exception
+    {
+        assertThat(new AbsentMatcher().matchesSafely(Absent.absent(), new Description.NullDescription()), CoreMatchers.is(true));
+        assertThat(new AbsentMatcher().matchesSafely(new Present<>("test"), new Description.NullDescription()), CoreMatchers.is(false));
+    }
+
+}

--- a/optional-testing/src/test/java/org/dmfs/optional/hamcrest/PresentMatcherTest.java
+++ b/optional-testing/src/test/java/org/dmfs/optional/hamcrest/PresentMatcherTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.optional.hamcrest;
+
+import org.dmfs.optional.Absent;
+import org.dmfs.optional.Present;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Description;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author marten
+ */
+public class PresentMatcherTest
+{
+    @Test
+    public void testMatchesSafely() throws Exception
+    {
+        assertThat(new PresentMatcher<>().matchesSafely(Absent.absent(), new Description.NullDescription()), CoreMatchers.is(false));
+        assertThat(new PresentMatcher<String>().matchesSafely(new Present<>("test"), new Description.NullDescription()), CoreMatchers.is(true));
+        assertThat(new PresentMatcher<>("test").matchesSafely(new Present<>("test"), new Description.NullDescription()), CoreMatchers.is(true));
+        assertThat(new PresentMatcher<>("test").matchesSafely(new Present<>("tost"), new Description.NullDescription()), CoreMatchers.is(false));
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'optional'
+include 'optional-testing'
 


### PR DESCRIPTION
You can use them like so
```
// just assert the optional is present, don't care about the value
assertThat(someOptional, isPresent<>());
// assert it's present and has a specific value (which supports equals)
assertThat(someOptional, isPresent<>("expectedValue"));
// assert it's present and matches another matcher
assertThat(someOptional, isPresent<>(contains(…)));
// assert the optional is absent
assertThat(someOptional, isAbsent());
```